### PR TITLE
load dependencies on module import and add back register_adapters to config

### DIFF
--- a/python/microns-coregistration/microns_coregistration/minnie_coregistration/minnie65_auto_match.py
+++ b/python/microns-coregistration/microns_coregistration/minnie_coregistration/minnie65_auto_match.py
@@ -11,3 +11,4 @@ config.register_externals(schema_obj)
 
 schema = dj.schema(schema_obj.value)
 schema.spawn_missing_classes()
+schema.connection.dependencies.load()

--- a/python/microns-coregistration/microns_coregistration/minnie_coregistration/minnie65_coregistration.py
+++ b/python/microns-coregistration/microns_coregistration/minnie_coregistration/minnie65_coregistration.py
@@ -11,3 +11,4 @@ config.register_externals(schema_obj)
 
 schema = dj.schema(schema_obj.value)
 schema.spawn_missing_classes()
+schema.connection.dependencies.load()

--- a/python/microns-coregistration/microns_coregistration/minnie_coregistration/minnie65_manual_match.py
+++ b/python/microns-coregistration/microns_coregistration/minnie_coregistration/minnie65_manual_match.py
@@ -11,3 +11,4 @@ config.register_externals(schema_obj)
 
 schema = dj.schema(schema_obj.value)
 schema.spawn_missing_classes()
+schema.connection.dependencies.load()


### PR DESCRIPTION
changes
- modules will now load dependencies on import
- replaces `register_adapters` which was accidentally removed